### PR TITLE
fixed copy command for windows in the copy backend method

### DIFF
--- a/build.py
+++ b/build.py
@@ -138,7 +138,7 @@ def build_executable():
 def copy_backend():
     print("Copying backend")
     if getPlatform() == "win32":
-        os.system("cp -r backend dist/REAL-Video-Enhancer/")
+        os.system('xcopy "./backend" "./dist/REAL-Video-Enhancer/" /E /I')
     if getPlatform() == "linux":
         os.system("cp -r backend bin/")
 


### PR DESCRIPTION
There was a failure in copying the files when running the project in a Windows environment. 

This fix only changes the copy command.

**Before:**

```python
def copy_backend():
    print("Copying backend")
    if getPlatform() == "win32":
        os.system("cp -r backend dist/REAL-Video-Enhancer/")
    if getPlatform() == "linux":
        os.system("cp -r backend bin/")
```

**After:**
```python
def copy_backend():
    print("Copying backend")
    if getPlatform() == "win32":
        os.system('xcopy "./backend" "./dist/REAL-Video-Enhancer/" /E /I')
    if getPlatform() == "linux":
        os.system("cp -r backend bin/")
```