### PR TITLE
Enhance output folder selection logic and add last input folder setting

### DIFF
--- a/REAL-Video-Enhancer.py
+++ b/REAL-Video-Enhancer.py
@@ -420,7 +420,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.upscaleContainer.setVisible(isUpscale or isDeblur or isDenoise or isDecompress)
         self.generalUpscaleContainer.setVisible(isUpscale)
         self.settings.readSettings()
-        self.setDefaultOutputFile(self.inputFileText.text(), self.settings.settings["output_folder_location"])
+        self.setDefaultOutputFile(self.inputFileText.text(), str(os.path.dirname(self.inputFileText.text())) if (self.isVideoLoaded and len(self.batchVideos) == 0 and os.path.exists(os.path.dirname(self.inputFileText.text()))) else self.settings.settings["output_folder_location"])
         self.updateVideoGUIText()
         self.startTimeSpinBox.setMaximum(self.videoLength)
         self.endTimeSpinBox.setMaximum(self.videoLength)
@@ -738,10 +738,11 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         inputFile, _ = QFileDialog.getOpenFileName(
             parent=self,
             caption="Select File",
-            dir=self.homeDir,
+            dir=self.settings.settings["last_input_folder_location"] if os.path.exists(self.settings.settings["last_input_folder_location"]) else self.homeDir,
             filter=fileFilter,
         )
         self.loadVideo(inputFile)
+        self.settings.writeSetting("last_input_folder_location", str(os.path.dirname(inputFile)))
     
     def openBatchFiles(self):
         inputFolder = QFileDialog.getExistingDirectory(
@@ -838,7 +839,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     # output file button
     def openOutputFolder(self):
         """
-        Opens a folder,
+        Opens home folder or the same folder as the input file only if the input file is a single file,
         sets the directory that is selected to the self.outputFolder variable
         sets the outputFileText to the output directory
 
@@ -847,7 +848,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         outputFolder = QFileDialog.getExistingDirectory(
             self,
             caption="Select Output Directory",
-            dir=self.homeDir,
+            dir=str(os.path.dirname(self.inputFileText.text())) if (self.isVideoLoaded and len(self.batchVideos) == 0 and os.path.exists(os.path.dirname(self.inputFileText.text()))) else self.homeDir,
         )
         self.outputFileText.setText(
             os.path.join(outputFolder, self.setDefaultOutputFile(self.inputFileText.text(), outputFolder))

--- a/src/ui/SettingsTab.py
+++ b/src/ui/SettingsTab.py
@@ -342,6 +342,9 @@ class Settings:
             "output_folder_location": os.path.join(f"{HOME_PATH}", "Videos")
             if PLATFORM != "darwin"
             else os.path.join(f"{HOME_PATH}", "Desktop"),
+            "last_input_folder_location": os.path.join(f"{HOME_PATH}", "Videos")
+            if PLATFORM != "darwin"
+            else os.path.join(f"{HOME_PATH}", "Desktop"),
             "uhd_mode": "True",
             "ncnn_gpu_id": "0",
             "pytorch_gpu_id": "0",
@@ -387,6 +390,7 @@ class Settings:
             "discord_rich_presence": ("True", "False"),
             "video_quality": ("Low", "Medium", "High", "Very High"),
             "output_folder_location": "ANY",
+            "last_input_folder_location": "ANY",
             "uhd_mode": ("True", "False"),
             "ncnn_gpu_id": "ANY",
             "pytorch_gpu_id": "ANY",


### PR DESCRIPTION
- Improved the logic for selecting the default output folder: now prefers the input file's directory when a single file is loaded, otherwise falls back to the saved output folder location.
- Added a new setting to remember the last input folder location, and updated the file dialog to use this as the default directory if available.
- Updated the settings structure to include `last_input_folder_location` with appropriate defaults and validation.

## Files changed

- `REAL-Video-Enhancer.py`
- `src/ui/SettingsTab.py`

## Motivation

These changes make the file selection process more intuitive and efficient for users, reducing repetitive navigation and aligning