### PR TITLE
Fix slow mode not using the new time

### DIFF
--- a/backend/src/FFmpegBuffers.py
+++ b/backend/src/FFmpegBuffers.py
@@ -217,7 +217,7 @@ class FFmpegWrite(Buffer):
                 "-loglevel",
                 "error",
                 "-framerate",
-                f"{self.fps*self.ceilInterpolateFactor}",
+                f"{self.fps*self.ceilInterpolateFactor if not self.slowmo_mode else self.fps}",
                 "-f",
                 "rawvideo",
                 "-pix_fmt",
@@ -229,7 +229,7 @@ class FFmpegWrite(Buffer):
                 "-i",
                 "-",
                 "-to",
-                str(self.end_time-self.start_time),
+                str((self.end_time-self.start_time) if not self.slowmo_mode else ((self.end_time-self.start_time)*self.ceilInterpolateFactor)),
                 "-r",
                 f"{self.outputFPS}",
                 "-f",
@@ -285,7 +285,7 @@ class FFmpegWrite(Buffer):
 
             command += [
                 "-framerate",
-                f"{self.fps*self.interpolateFactor}",
+                f"{self.fps*self.ceilInterpolateFactor if not self.slowmo_mode else self.fps}",
                 "-f",
                 "rawvideo",
                 "-pix_fmt",
@@ -383,7 +383,7 @@ class FFmpegWrite(Buffer):
                 ]
             command +=[
                 "-to",
-                str(self.end_time-self.start_time),
+                str((self.end_time-self.start_time) if not self.slowmo_mode else ((self.end_time-self.start_time)*self.ceilInterpolateFactor)),
                 f"{self.outputFile}",
             ]
 


### PR DESCRIPTION
This pull request resolves an issue in the slow motion mode (`slowmo_mode`) where the new time settings were not being applied correctly. The following changes were made:

### Before / After:
## Before:
video 30fps 1s --> x4 --> video 30fps 1s (with slow mode the first 1s)
## After:
video 30fps 1s --> x4 --> video 30fps 4s (with slow mode all the video)

### Changes
1. **Frame Rate (`fps`) Adjustment**:
   - In slow motion mode, the original frame rate is now used instead of multiplying it by the interpolation factor (`ceilInterpolateFactor`).

1. **End Time Calculation**:
   - The end time is now correctly multiplied by the interpolation factor in slow motion mode to reflect the extended duration.

1. **FFmpeg Command Updates**:
   - Updated the FFmpeg commands to incorporate these adjustments, ensuring accurate video rendering in slow motion mode.

### Files Modified
- `backend/src/FFmpegBuffers.py`

### Testing
- Verified that the slow motion mode now uses the correct frame rate and time settings.
- Ensured that the FFmpeg commands are generated correctly for both normal and slow motion modes.

Btw, why the change of:
```diff
REAL-Video-Enhancer.py:431
- self.setDefaultOutputFile(self.inputFileText.text(), str(os.path.dirname(self.inputFileText.text())) if (self.isVideoLoaded and len(self.batchVideos) == 0 and os.path.exists(os.path.dirname(self.inputFileText.text()))) else self.settings.settings["output_folder_location"])
+ self.setDefaultOutputFile(self.inputFileText.text(), self.settings.settings["output_folder_location"])
```