### PR TITLE
Fix incomplete video encoding inside some shell loops

### DIFF
--- a/backend/src/FFmpegBuffers.py
+++ b/backend/src/FFmpegBuffers.py
@@ -82,6 +82,7 @@ class FFmpegRead(Buffer):
         
         command = [
             f"{self.ffmpeg_path}",
+            "-nostdin",
             "-i",
             f"{self.inputFile}",
         ]


### PR DESCRIPTION
I probably had the same issue as #191 (log output is very similar), and this PR fixes it.

I traced the issue to ffmpeg reader (as was suggested in the issue above) and while testing different options I found by trial-and-error that adding `"-nostdin"` to ffmpeg arguments works.

The trigger for the issue was that I am using a Bash command like this for batch video processing:

```bash
# read files backwards
ls -1 "$input_dir"/*.mp4 | tac | while read -r f; do
    # RVE is executed here for each file "$f"
done
```

Without the `"-nostdin"` flag, ffmpeg gobbles up the output of `ls` until it finds a random `q` character and quits. It takes ~40 minutes of encoding for this to happen, maybe because the gobbling is quite slow (~1 character per second?)

Relevant StackOverflow ticket: https://stackoverflow.com/questions/21634088/execute-ffmpeg-command-in-a-loop

I'd argue that it's better to use the `"-nostdin"` flag in any case, even if you don't care about poorly written scripts :sweat_smile:. Interactivity should probably be disabled for batch processing like this, in general. And it stops ffmpeg from periodically outputting this text hint: 

```
Enter command: <target>|all <time>|-1 <command>[ <argument>]
```