### PR TITLE
Add option to preserve input folder structure for output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ github/
 __pycache__/
 *.py[cod]
 *$py.class
+
+# Dev files
+build
+dist
+venv

--- a/REAL-Video-Enhancer.py
+++ b/REAL-Video-Enhancer.py
@@ -462,7 +462,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.upscaleContainer.setVisible(isUpscale or isDeblur or isDenoise or isDecompress)
         self.generalUpscaleContainer.setVisible(isUpscale)
         self.settings.readSettings()
-        self.setDefaultOutputFile(self.inputFileText.text(), str(os.path.dirname(self.inputFileText.text())) if (self.settings.settings["use_same_output_folder_from_input_enabled"] == "True" and self.isVideoLoaded and len(self.batchVideos) == 0 and os.path.exists(os.path.dirname(self.inputFileText.text()))) else self.settings.settings["output_folder_location"])
+        self.setDefaultOutputFile(self.inputFileText.text(), str(os.path.dirname(self.inputFileText.text())) if (self.settings.settings["use_same_output_folder_as_input_file_enabled"] == "True" and self.isVideoLoaded and len(self.batchVideos) == 0 and os.path.exists(os.path.dirname(self.inputFileText.text()))) else self.settings.settings["output_folder_location"])
         self.updateVideoGUIText()
         self.startTimeSpinBox.setMaximum(self.videoLength)
         self.endTimeSpinBox.setMaximum(self.videoLength)

--- a/REAL-Video-Enhancer.py
+++ b/REAL-Video-Enhancer.py
@@ -462,7 +462,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.upscaleContainer.setVisible(isUpscale or isDeblur or isDenoise or isDecompress)
         self.generalUpscaleContainer.setVisible(isUpscale)
         self.settings.readSettings()
-        self.setDefaultOutputFile(self.inputFileText.text(), self.settings.settings["output_folder_location"])
+        self.setDefaultOutputFile(self.inputFileText.text(), str(os.path.dirname(self.inputFileText.text())) if (self.settings.settings["use_same_output_folder_from_input_enabled"] == "True" and self.isVideoLoaded and len(self.batchVideos) == 0 and os.path.exists(os.path.dirname(self.inputFileText.text()))) else self.settings.settings["output_folder_location"])
         self.updateVideoGUIText()
         self.startTimeSpinBox.setMaximum(self.videoLength)
         self.endTimeSpinBox.setMaximum(self.videoLength)

--- a/src/ui/SettingsTab.py
+++ b/src/ui/SettingsTab.py
@@ -169,6 +169,12 @@ class SettingsTab:
         self.parent.output_folder_location.textChanged.connect(
             lambda: self.writeOutputFolder()
         )
+        self.parent.use_same_output_folder_from_input_enabled.stateChanged.connect(
+            lambda: self.settings.writeSetting(
+                "use_same_output_folder_from_input_enabled",
+                "True" if self.parent.use_same_output_folder_from_input_enabled.isChecked() else "False",
+            )
+        )
 
         self.parent.resetSettingsBtn.clicked.connect(self.resetSettings)
 
@@ -325,6 +331,9 @@ class SettingsTab:
         self.parent.select_output_folder_location_btn.clicked.connect(
             self.selectOutputFolder
         )
+        self.parent.use_same_output_folder_from_input_enabled.setChecked(
+            self.settings.settings["use_same_output_folder_from_input_enabled"] == "True"
+        )
         self.parent.uhd_mode.setChecked(self.settings.settings["uhd_mode"] == "True")
         self.parent.ncnn_gpu_id.setValue(int(self.settings.settings["ncnn_gpu_id"]))
         self.parent.pytorch_gpu_id.setValue(
@@ -401,6 +410,7 @@ class Settings:
             "discord_rich_presence": "False",
             "video_quality": "High",
             "output_folder_location": output_folder_default,
+            "use_same_output_folder_from_input_enabled": "False",
             "last_input_folder_location": output_folder_default,
             "uhd_mode": "True",
             "ncnn_gpu_id": "0",
@@ -446,6 +456,7 @@ class Settings:
             "discord_rich_presence": ("True", "False"),
             "video_quality": ("Low", "Medium", "High", "Very_High", "Ultra", "Lossless"),
             "output_folder_location": "ANY",
+            "use_same_output_folder_from_input_enabled": ("True", "False"),
             "last_input_folder_location": "ANY",
             "uhd_mode": ("True", "False"),
             "ncnn_gpu_id": "ANY",

--- a/src/ui/SettingsTab.py
+++ b/src/ui/SettingsTab.py
@@ -169,10 +169,10 @@ class SettingsTab:
         self.parent.output_folder_location.textChanged.connect(
             lambda: self.writeOutputFolder()
         )
-        self.parent.use_same_output_folder_from_input_enabled.stateChanged.connect(
+        self.parent.use_same_output_folder_as_input_file_enabled.stateChanged.connect(
             lambda: self.settings.writeSetting(
-                "use_same_output_folder_from_input_enabled",
-                "True" if self.parent.use_same_output_folder_from_input_enabled.isChecked() else "False",
+                "use_same_output_folder_as_input_file_enabled",
+                "True" if self.parent.use_same_output_folder_as_input_file_enabled.isChecked() else "False",
             )
         )
 
@@ -331,8 +331,8 @@ class SettingsTab:
         self.parent.select_output_folder_location_btn.clicked.connect(
             self.selectOutputFolder
         )
-        self.parent.use_same_output_folder_from_input_enabled.setChecked(
-            self.settings.settings["use_same_output_folder_from_input_enabled"] == "True"
+        self.parent.use_same_output_folder_as_input_file_enabled.setChecked(
+            self.settings.settings["use_same_output_folder_as_input_file_enabled"] == "True"
         )
         self.parent.uhd_mode.setChecked(self.settings.settings["uhd_mode"] == "True")
         self.parent.ncnn_gpu_id.setValue(int(self.settings.settings["ncnn_gpu_id"]))
@@ -410,7 +410,7 @@ class Settings:
             "discord_rich_presence": "False",
             "video_quality": "High",
             "output_folder_location": output_folder_default,
-            "use_same_output_folder_from_input_enabled": "False",
+            "use_same_output_folder_as_input_file_enabled": "False",
             "last_input_folder_location": output_folder_default,
             "uhd_mode": "True",
             "ncnn_gpu_id": "0",
@@ -456,7 +456,7 @@ class Settings:
             "discord_rich_presence": ("True", "False"),
             "video_quality": ("Low", "Medium", "High", "Very_High", "Ultra", "Lossless"),
             "output_folder_location": "ANY",
-            "use_same_output_folder_from_input_enabled": ("True", "False"),
+            "use_same_output_folder_as_input_file_enabled": ("True", "False"),
             "last_input_folder_location": "ANY",
             "uhd_mode": ("True", "False"),
             "ncnn_gpu_id": "ANY",

--- a/testRVEInterface.ui
+++ b/testRVEInterface.ui
@@ -4509,7 +4509,7 @@ QTabWidget::pane { /* The tab widget frame */
                               </widget>
                              </item>
                              <item>
-                              <widget class="QWidget" name="use_same_output_folder_from_inputContainer" native="true">
+                              <widget class="QWidget" name="use_same_output_folder_as_input_fileContainer" native="true">
                                <layout class="QHBoxLayout" name="horizontalLayout_61">
                                 <property name="spacing">
                                  <number>10</number>
@@ -4534,7 +4534,7 @@ QTabWidget::pane { /* The tab widget frame */
                                    </font>
                                   </property>
                                   <property name="text">
-                                   <string>Use same output folder from input file folder</string>
+                                   <string>Use the same output folder as the input file</string>
                                   </property>
                                  </widget>
                                 </item>
@@ -4560,7 +4560,7 @@ QTabWidget::pane { /* The tab widget frame */
                                    </size>
                                   </property>
                                   <property name="toolTip">
-                                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Use same output folder as input:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- Enabled: Use the same output folder as the inputfile folder. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Use the same output folder as the input file:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- Enabled: The output folder will be the same as the directory where the original input file is located. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                                   </property>
                                   <property name="text">
                                    <string/>
@@ -4574,7 +4574,7 @@ QTabWidget::pane { /* The tab widget frame */
                                  </widget>
                                 </item>
                                 <item>
-                                 <widget class="QCheckBox" name="use_same_output_folder_from_input_enabled">
+                                 <widget class="QCheckBox" name="use_same_output_folder_as_input_file_enabled">
                                   <property name="text">
                                    <string/>
                                   </property>

--- a/testRVEInterface.ui
+++ b/testRVEInterface.ui
@@ -4509,6 +4509,81 @@ QTabWidget::pane { /* The tab widget frame */
                               </widget>
                              </item>
                              <item>
+                              <widget class="QWidget" name="use_same_output_folder_from_inputContainer" native="true">
+                               <layout class="QHBoxLayout" name="horizontalLayout_61">
+                                <property name="spacing">
+                                 <number>10</number>
+                                </property>
+                                <property name="leftMargin">
+                                 <number>0</number>
+                                </property>
+                                <property name="topMargin">
+                                 <number>0</number>
+                                </property>
+                                <property name="rightMargin">
+                                 <number>0</number>
+                                </property>
+                                <property name="bottomMargin">
+                                 <number>0</number>
+                                </property>
+                                <item>
+                                 <widget class="QLabel" name="label_26">
+                                  <property name="font">
+                                   <font>
+                                    <pointsize>12</pointsize>
+                                   </font>
+                                  </property>
+                                  <property name="text">
+                                   <string>Use same output folder from input file folder</string>
+                                  </property>
+                                 </widget>
+                                </item>
+                                <item>
+                                 <spacer name="horizontalSpacer_36">
+                                  <property name="orientation">
+                                   <enum>Qt::Orientation::Horizontal</enum>
+                                  </property>
+                                  <property name="sizeHint" stdset="0">
+                                   <size>
+                                    <width>40</width>
+                                    <height>20</height>
+                                   </size>
+                                  </property>
+                                 </spacer>
+                                </item>
+                                <item>
+                                 <widget class="QLabel" name="label_27">
+                                  <property name="maximumSize">
+                                   <size>
+                                    <width>25</width>
+                                    <height>25</height>
+                                   </size>
+                                  </property>
+                                  <property name="toolTip">
+                                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Use same output folder as input:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- Enabled: Use the same output folder as the inputfile folder. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                                  </property>
+                                  <property name="text">
+                                   <string/>
+                                  </property>
+                                  <property name="pixmap">
+                                   <pixmap resource="resources.qrc">:/icons/icons/info.svg</pixmap>
+                                  </property>
+                                  <property name="scaledContents">
+                                   <bool>true</bool>
+                                  </property>
+                                 </widget>
+                                </item>
+                                <item>
+                                 <widget class="QCheckBox" name="use_same_output_folder_from_input_enabled">
+                                  <property name="text">
+                                   <string/>
+                                  </property>
+                                 </widget>
+                                </item>
+                               </layout>
+                              </widget>
+                             </item>
+                             <item>
                               <widget class="QWidget" name="sceneChangeDetectionSettingContainer" native="true">
                                <layout class="QHBoxLayout" name="horizontalLayout_17">
                                 <property name="spacing">


### PR DESCRIPTION
This PR adds a new user setting to control whether output files are saved in the same folder as the input file or in a common parent folder. This provides greater flexibility in organizing processed videos.

**Problem**:
Currently, all output files are saved to a single output directory (e.g., `C:\Users\user\Videos`). This can clutter the folder and mix processed videos from different subfolders, making organization difficult.

**Solution**:
Introduces a toggle setting **"Use the same output folder as the input file"**, which when:
- **Disabled** (default): Outputs go to the common output directory, preserving current behavior.
- **Enabled**: Outputs are saved to the same folder as the input file, maintaining the original folder structure.

**Examples**:

1. **Option Disabled** (default):
   - Input: `C:\Users\user\Videos\subfolder\video.mp4`
   - Auto Settled Output: `C:\Users\user\Videos\video_...settings....mp4`

2. **Option Enabled**:
   - Input: `C:\Users\user\Videos\subfolder\video.mp4`
   - Auto Settled Output: `C:\Users\user\Videos\subfolder\video_...settings....mp4`

**Notes**:
- Reintroduces and builds upon the changes from #136 with improved configurability.
- Follows up on discussion from #145.
- Default behavior remains unchanged.

**Summary of Changes**:
- [x] Added new boolean setting
- [x] Modified output path logic to respect the new setting
- [x] Updated UI to include the toggle option
- [x] Ensured existing workflows remain unaffected
