### PR TITLE
Add proper macOS support, with DMG build script

### DIFF
--- a/build.py
+++ b/build.py
@@ -156,9 +156,13 @@ class BuildManager:
         print("Building GUI")
         #set_mainwindow_size()
         if PLATFORM == "darwin" or PLATFORM == "linux":
-            os.system(
-                f"{self.python_manager.get_venv_site_packages()}/PySide6/Qt/libexec/uic -g python testRVEInterface.ui > mainwindow.py"
-            )
+            uic_path = f"{self.python_manager.get_venv_site_packages()}/PySide6/Qt/libexec/uic"
+            with open("mainwindow.py", "w", encoding="utf-8") as mainwindow_out:
+                subprocess.run(
+                    [uic_path, "-g", "python", "testRVEInterface.ui"],
+                    stdout=mainwindow_out,
+                    check=True,
+                )
         if PLATFORM == "win32":
             os.system(
                 r".\venv\Lib\site-packages\PySide6\uic.exe -g python testRVEInterface.ui > mainwindow.py"
@@ -167,9 +171,13 @@ class BuildManager:
     def build_resources(self):
         print("Building resources.rc")
         if PLATFORM == "darwin" or PLATFORM == "linux":
-            os.system(
-                f"{self.python_manager.get_venv_site_packages()}/PySide6/Qt/libexec/rcc -g python resources.qrc > resources_rc.py"
-            )
+            rcc_path = f"{self.python_manager.get_venv_site_packages()}/PySide6/Qt/libexec/rcc"
+            with open("resources_rc.py", "w", encoding="utf-8") as resources_out:
+                subprocess.run(
+                    [rcc_path, "-g", "python", "resources.qrc"],
+                    stdout=resources_out,
+                    check=True,
+                )
         if PLATFORM == "win32":
             os.system(
                 r".\venv\Lib\site-packages\PySide6\rcc.exe -g python resources.qrc > resources_rc.py"

--- a/scripts/build_macos_dmg.sh
+++ b/scripts/build_macos_dmg.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/build_macos_dmg.sh [options]
+
+Options:
+  --python PATH   Python executable to use (default: python3.11)
+  --no-clean      Keep existing build/venv artifacts
+  --help          Show this help
+USAGE
+}
+
+PYTHON_BIN="python3.11"
+CLEAN=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --python)
+      PYTHON_BIN="${2:-}"
+      shift 2
+      ;;
+    --no-clean)
+      CLEAN=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This script only supports macOS." >&2
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "Python executable not found: $PYTHON_BIN" >&2
+  echo "Install Python 3.11 (recommended), or pass --python /path/to/python" >&2
+  exit 1
+fi
+
+APP_NAME="REAL-Video-Enhancer"
+APP_BUNDLE="dist/${APP_NAME}.app"
+VERSION="$(sed -nE 's/^version = "([^"]+)"/\1/p' src/version.py | head -n 1)"
+if [[ -z "$VERSION" ]]; then
+  VERSION="unknown"
+fi
+
+DMG_NAME="${APP_NAME}-macOS-${VERSION}.dmg"
+DMG_PATH="dist/${DMG_NAME}"
+DMG_ROOT="dist/dmg-root"
+
+if [[ "$CLEAN" -eq 1 ]]; then
+  echo "==> Cleaning previous build artifacts"
+  rm -rf venv dist build __pycache__ mainwindow.py resources_rc.py REAL-Video-Enhancer.spec
+fi
+
+echo "==> Building app bundle with ${PYTHON_BIN}"
+"$PYTHON_BIN" build.py --build pyinstaller --copy_backend
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+  echo "App bundle not found: $APP_BUNDLE" >&2
+  exit 1
+fi
+
+echo "==> Creating DMG layout"
+rm -rf "$DMG_ROOT"
+mkdir -p "$DMG_ROOT"
+cp -R "$APP_BUNDLE" "$DMG_ROOT/"
+ln -s /Applications "$DMG_ROOT/Applications"
+
+echo "==> Packaging DMG"
+hdiutil create -volname "REAL Video Enhancer" -srcfolder "$DMG_ROOT" -ov -format UDZO "$DMG_PATH"
+
+echo "==> DMG created"
+ls -lh "$DMG_PATH"
+shasum -a 256 "$DMG_PATH"
+
+echo "Done. Output: $ROOT_DIR/$DMG_PATH"


### PR DESCRIPTION
**REVISED build.py**
- macOS/Linux builds now reliably generate mainwindow.py and resources_rc.py.
- Errors in Qt code generation now fail fast with actionable exceptions instead of continuing with broken artifacts.
- Windows build path logic remains unchanged.

**NEW build_macos_dmg.sh**
- Validates macOS environment.
- Uses python3.11 by default (or --python PATH).
- Optionally cleans prior artifacts (default behavior; disable with --no-clean).
- Runs build.py --build pyinstaller --copy_backend.
- Creates a drag-and-drop DMG (.app + /Applications symlink).
- Prints output file size and SHA-256.

[macOS .dmg Installer File](https://drive.google.com/file/d/1u0o6pp5d2h2WseWniar0XijwrN6BVMGb/view?usp=sharing)