### PR TITLE
fix: force eval mode for DAT models to resolve BatchNorm training mode compatibility

### DIFF
--- a/backend/src/pytorch/UpscaleModelWrapper.py
+++ b/backend/src/pytorch/UpscaleModelWrapper.py
@@ -34,6 +34,7 @@ class UpscaleModelWrapper:
         # inference and get re-load state dict due to issue with span.
         with torch.inference_mode():
             model = self.inference_helper
+            model.eval()
             model(test_input)
             output = model(test_input)
             self.__model.load_state_dict(model.state_dict()) # reload state dict to fix span

--- a/backend/src/pytorch/UpscaleModelWrapper.py
+++ b/backend/src/pytorch/UpscaleModelWrapper.py
@@ -67,6 +67,7 @@ class UpscaleModelWrapper:
                 assert isinstance(model, ImageModelDescriptor)
                 self.__scale = model.scale
                 model = model.model
+                model.eval()  # Fix BatchNorm training mode issue for neosr-trained models
                 self.__model = model
                 self.inference_helper = self.__model
                 self.__dummy_input_pre_channels = [1]


### PR DESCRIPTION
## Summary
- Set models to eval mode after loading via spandrel
- Fixes BatchNorm training mode error when using neosr-trained models
## Problem
Models trained with neosr (e.g., [4x-UltraSharpV2](https://openmodeldb.info/models/4x-UltraSharpV2)) have BatchNorm layers in training mode that require `batch_size > 1`. When loaded with batch_size=1 for testing, this causes:
ValueError: Expected more than 1 value per channel when training, got input size torch.Size(1, 22, 1, 1)
## Solution
Force `model.eval()` after loading models via spandrel. This is a defensive fix that ensures any model with BatchNorm layers in training mode gets set to eval mode.
## Scope
This fix applies to **PyTorch backend only**.
## Testing
- [4x-UltraSharpV2](https://openmodeldb.info/models/4x-UltraSharpV2) - DAT2 architecture, neosr-trained
- [4x-Nomos8kDAT](https://openmodeldb.info/models/4x-Nomos8kDAT) - DAT architecture, official repo trained
## Changes
- `backend/src/pytorch/UpscaleModelWrapper.py`: Add `model.eval()` after spandrel model load